### PR TITLE
Adds dial region

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -21,7 +21,7 @@ body {
 	margin: 1rem;
 	max-width: 61rem;
 }
-.leftbar {
+.thincolumn {
 	max-width: 11rem;
 }
 .masthead {

--- a/dpm_classy.info.yml
+++ b/dpm_classy.info.yml
@@ -25,4 +25,4 @@ regions:
 
 screenshot: screenshot.png
 
-version: 0.6.0-beta1
+version: 0.6.0-beta2

--- a/dpm_classy.info.yml
+++ b/dpm_classy.info.yml
@@ -16,6 +16,7 @@ logo: img/monitor-icon.png
 
 regions:
   header: Header
+  dial: Dial
   sidebar: Sidebar
   highlight: Highlight
   help: Help
@@ -24,4 +25,4 @@ regions:
 
 screenshot: screenshot.png
 
-version: 0.4.0
+version: 0.6.0-beta1

--- a/templates/block/block--system-branding-block.html.twig
+++ b/templates/block/block--system-branding-block.html.twig
@@ -15,7 +15,7 @@
 #}
 {% block content %}
   <div class="row masthead">
-    <div class="column leftbar">
+    <div class="column thincolumn">
       {% if site_logo %}
         <a href="{{ path('<front>') }}" title="{{ 'Home'|t }}" rel="home" class="site-logo">
           <img src="{{ site_logo }}" alt="{{ 'Home'|t }}" />

--- a/templates/layout/region--dial.html.twig
+++ b/templates/layout/region--dial.html.twig
@@ -1,0 +1,25 @@
+{#
+/**
+ * @file
+ * Theme override to display a region.
+ *
+ * Available variables:
+ * - content: The content for this region, typically blocks.
+ * - attributes: HTML attributes for the region <div>.
+ * - region: The name of the region variable as defined in the theme's
+ *   .info.yml file.
+ *
+ * @see template_preprocess_region()
+ */
+#}
+{%
+  set classes = [
+    'region',
+    'region-' ~ region|clean_class,
+  ]
+%}
+{% if content %}
+  <div{{ attributes.addClass(classes).addClass('column').addClass('thincolumn') }}>
+    {{ content }}
+  </div>
+{% endif %}

--- a/templates/layout/region--header.html.twig
+++ b/templates/layout/region--header.html.twig
@@ -1,0 +1,25 @@
+{#
+/**
+ * @file
+ * Theme override to display a region.
+ *
+ * Available variables:
+ * - content: The content for this region, typically blocks.
+ * - attributes: HTML attributes for the region <div>.
+ * - region: The name of the region variable as defined in the theme's
+ *   .info.yml file.
+ *
+ * @see template_preprocess_region()
+ */
+#}
+{%
+  set classes = [
+    'region',
+    'region-' ~ region|clean_class,
+  ]
+%}
+{% if content %}
+  <div{{ attributes.addClass(classes).addClass('column') }}>
+    {{ content }}
+  </div>
+{% endif %}

--- a/templates/system/page.html.twig
+++ b/templates/system/page.html.twig
@@ -54,18 +54,25 @@
 
 <div class="wrapper">
 
-  <div id="header" role="heading">
+  <div class="row" id="header" role="heading">
     {# Header #}
     {% if page.header %}
     {% block header %}
       {{ page.header }}
     {% endblock %}
     {% endif %}
+
+    {# Dial #}
+    {% if page.dial %}
+    {% block dial %}
+      {{ page.dial }}
+    {% endblock %}
+    {% endif %}
   </div>
 
   {% block main %}
   <div class="row main">
-    <div class="column leftbar">
+    <div class="column thincolumn">
       {# Sidebar #}
       {% if page.sidebar %}
       {% block sidebar %}


### PR DESCRIPTION
## Status
_Use labels (`review needed`, `in progress`, or `paused`) to declare status_

#### What does this PR do?
This adds a region for the navigation dial feature on the existing DPM site. This implementation leads to the following changes:
- Creation of a Dial region in `dpm_classy.info.yml` and `page.html.twig`
- Addition of a `row` class in `page.html.twig`, and `column` classes in two new template files (for the Dial region, and the existing Header region)
- Renaming of the `leftbar` class to `thincolumn` as we're now using those classes on the left navigation column, and the dial region (which isn't on the left).

#### Helpful background context (if appropriate)
You can see the dial feature by looking around the tutorial on the existing site - for example at: https://dpworkshop.org/dpm-eng/eng_index.html
https://dpworkshop.org/dpm-eng/timeline/index.html
https://dpworkshop.org/dpm-eng/foundation/index.html

The corresponding pages on the upgraded site, without this region, are at:
http://live-dpworkshop.pantheonsite.io/dpm-eng/eng_index.html
http://live-dpworkshop.pantheonsite.io/dpm-eng/timeline/index.html
http://live-dpworkshop.pantheonsite.io/dpm-eng/foundation/index.html

#### How can a reviewer manually see the effects of these changes?
I've deployed this version of the theme, and built out the dial itself, on the Test site:
http://test-dpworkshop.pantheonsite.io/dpm-eng/eng_index.html
http://test-dpworkshop.pantheonsite.io/dpm-eng/timeline/index.html
http://test-dpworkshop.pantheonsite.io/dpm-eng/foundation/index.html

#### What are the relevant tickets?
- https://mitlibraries.atlassian.net/browse/DU-24 (decides strategy)
- https://mitlibraries.atlassian.net/browse/DU-47 (implements in the theme)

#### Requires Database Migrations?
NO

#### Includes new or updated dependencies?
NO
