### PR TITLE
Moves to SCSS precompiling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
+/css/*.css.map
 /vendor/

--- a/README.md
+++ b/README.md
@@ -6,3 +6,18 @@ DPM_Classy
 DPM_Classy is a Drupal 8 theme (specifcally a sub-theme of [Classy](https://www.drupal.org/docs/8/core/themes/classy-theme)) that was developed for the [Digital Preservation Management](https://dpworkshop.org/) website.
 
 ![Screenshot of DPM Classy in action](https://github.com/MITLibraries/dpm_classy/blob/master/screenshot.png)
+
+Contributing
+------------
+
+Please note that this theme uses [SCSS syntax](https://sass-lang.com/documentation/syntax#scss) for its styles - but the compilation must be done by the contributor. Your contributions should include both changes to the source stylesheets (in `/scss`) as well as the compiled stylesheets (in `/css`).
+
+The recommended workflow is to have the following command running in a separate terminal window while you develop:
+
+```
+/path/to/repository$ sass --watch scss/:css/
+```
+
+This will allow you to commit the same changes to both source and compiles stylesheets in one message.
+
+[For an introduction to this approach to stylesheets, please consult the SASS Basics resource.](https://sass-lang.com/guide)

--- a/composer.json
+++ b/composer.json
@@ -8,8 +8,5 @@
             "name": "Matt Bernhardt",
             "email": "mjbernha@mit.edu"
         }
-    ],
-    "require": {
-        "scssphp/scssphp": "^1.0"
-    }
+    ]
 }

--- a/css/callouts.css
+++ b/css/callouts.css
@@ -1,105 +1,112 @@
 /* Block styles */
 /* Case in point */
 #content div.case-in-point:before {
-	content: url('../img/point.gif');
-	padding-right: 0.5rem;
-	vertical-align: -50%;
+  content: url("../img/point.gif");
+  padding-right: 0.5rem;
+  vertical-align: -50%;
 }
 
 /* Check this out */
 #content div.check-out:before {
-	content: url('../img/checkmark.gif');
-	padding-right: 0.5rem;
-	vertical-align: -50%;
+  content: url("../img/checkmark.gif");
+  padding-right: 0.5rem;
+  vertical-align: -50%;
 }
 
 /* "Did you know" sidebar (either left or right) */
 #content div.did-you-know {
-	background: #fbfaf7;
-	box-shadow: 4px 4px 2px #888;
-	margin-bottom: 1rem;
-	padding: 0.5rem;
-	width: 30%;
+  background: #fbfaf7;
+  box-shadow: 4px 4px 2px #888;
+  margin-bottom: 1rem;
+  padding: 0.5rem;
+  width: 30%;
 }
+
 #content div.did-you-know.right {
-	clear: right;
-	float: right;
-	margin-left: 1rem;
+  clear: right;
+  float: right;
+  margin-left: 1rem;
 }
+
 #content div.did-you-know.left {
-	clear: left;
-	float: left;
-	margin-right: 1rem;
+  clear: left;
+  float: left;
+  margin-right: 1rem;
 }
+
 #content div.did-you-know h3 {
-	color: black;
-	border-bottom: 1px solid black;
-	margin-top: 0;
+  color: black;
+  border-bottom: 1px solid black;
+  margin-top: 0;
 }
 
 /* Exercise callout */
 #content div.exercise {
-	background: #fbfaf7;
-	border-bottom: 1rem solid #765013;
-	margin: 0 auto;
-	width: 90%;
+  background: #fbfaf7;
+  border-bottom: 1rem solid #765013;
+  margin: 0 auto;
+  width: 90%;
 }
+
 #content div.exercise h3 {
-	background: #765013;
-	color: #fff;
-	margin-top: 0;
-	text-align: center;
+  background: #765013;
+  color: #fff;
+  margin-top: 0;
+  text-align: center;
 }
+
 #content div.exercise p {
-	padding: 0.25rem;
+  padding: 0.25rem;
 }
 
 /* Highlight callout (Case in point, etc) */
 #content div.highlight {
-	background: #FBF9F6;
-	border: 1px solid #ddd2c2;
-	box-shadow: 4px 4px 2px #888;
-	clear: both;
-	margin: 0 auto;
-	margin-top: 1rem;
-	width: 80%;
+  background: #FBF9F6;
+  border: 1px solid #ddd2c2;
+  box-shadow: 4px 4px 2px #888;
+  clear: both;
+  margin: 0 auto;
+  margin-top: 1rem;
+  width: 80%;
 }
 
 /* Suggested actions */
 #content div.suggested:before {
-	content: url('../img/action.gif');
-	padding-right: 0.5rem;
-	vertical-align: -50%;
+  content: url("../img/action.gif");
+  padding-right: 0.5rem;
+  vertical-align: -50%;
 }
 
 /* Watch this spot */
 #content div.watch-this:before {
-	content: url('../img/watch_glass.gif');
-	padding-right: 0.5rem;
-	vertical-align: -50%;
+  content: url("../img/watch_glass.gif");
+  padding-right: 0.5rem;
+  vertical-align: -50%;
 }
 
 /* Inline styles */
 /* Organizational challenge */
 #content span.manager {
-	font-family: "Georgia", "Times New Roman", "Times", serif;
-	font-size: 14px;
-	font-weight: 700;
-	color: #ca0000;
+  font-family: "Georgia", "Times New Roman", "Times", serif;
+  font-size: 14px;
+  font-weight: 700;
+  color: #ca0000;
 }
 
 /* Technical challenge */
 #content span.technical {
-	font-family: "Georgia", "Times New Roman", "Times", serif;
-	font-size: 14px;
-	font-weight: 700;
-	color: #EEA643;
+  font-family: "Georgia", "Times New Roman", "Times", serif;
+  font-size: 14px;
+  font-weight: 700;
+  color: #EEA643;
 }
 
 /* Resource challenge */
 #content span.resource {
-	font-family: "Georgia", "Times New Roman", "Times", serif;
-	font-size: 14px;
-	font-weight: 700;
-	color: #6f8531;
+  font-family: "Georgia", "Times New Roman", "Times", serif;
+  font-size: 14px;
+  font-weight: 700;
+  color: #6f8531;
 }
+
+/*# sourceMappingURL=callouts.css.map */

--- a/css/selfquiz.css
+++ b/css/selfquiz.css
@@ -1,43 +1,55 @@
 .selfquiz {
-	padding: 8px 0;
+  padding: 8px 0;
 }
+
 .selfquiz .question {
-	padding-bottom: 8px;
+  padding-bottom: 8px;
 }
+
 .selfquiz .prompt {
-	font-size: 16px;
-	font-weight: bold;
-	padding-bottom: 8px;
+  font-size: 16px;
+  font-weight: bold;
+  padding-bottom: 8px;
 }
+
 .selfquiz .feedback {
-	font-size: 14px;
-	color: red;
-	padding-bottom: 16px;
+  font-size: 14px;
+  color: red;
+  padding-bottom: 16px;
 }
+
 .selfquiz .answers {
-	font-size: 14px;
-	list-style-type: none;
-	padding-bottom: 4px;
-	padding-left: 0;
+  font-size: 14px;
+  list-style-type: none;
+  padding-bottom: 4px;
+  padding-left: 0;
 }
+
 .selfquiz .answers label {
-	font-weight: normal;
+  font-weight: normal;
 }
+
 .selfquiz .answers li {
-	padding-bottom: 4px;
+  padding-bottom: 4px;
 }
+
 .selfquiz .score {
-	color: red;
-	font-size: 20px;
-	font-weight: bold;
-	padding-bottom: 16px;
+  color: red;
+  font-size: 20px;
+  font-weight: bold;
+  padding-bottom: 16px;
 }
+
 .selfquiz .correct {
-	background: #66ff66;
+  background: #66ff66;
 }
+
 .selfquiz .wrong {
-	background: #ff6666;
+  background: #ff6666;
 }
+
 .selfquiz .hidden {
-	display: none;
+  display: none;
 }
+
+/*# sourceMappingURL=selfquiz.css.map */

--- a/css/style.css
+++ b/css/style.css
@@ -1,58 +1,55 @@
 body {
-	background: #fff url('../img/background.png') top left no-repeat;
-	color: #000;
+  background: #fff url("../img/background.png") top left no-repeat;
+  color: #000;
 }
 
 .row {
-	display: flex;
-	flex-direction: row;
-	flex-wrap: wrap;
-	width: 100%;
+  display: flex;
+  flex-direction: row;
+  flex-wrap: wrap;
+  width: 100%;
 }
 
 .column {
-	display: flex;
-	flex-direction: column;
-	flex-basis: 100%;
-	flex: 1;
+  display: flex;
+  flex-direction: column;
+  flex-basis: 100%;
+  flex: 1;
 }
 
 .wrapper {
-	margin: 1rem;
-	max-width: 61rem;
+  margin: 1rem;
+  max-width: 61rem;
 }
+
 .thincolumn {
-	max-width: 11rem;
+  max-width: 11rem;
 }
+
 .masthead {
-	height: 11rem;
-}
-.main {
-
-}
-.colophon {
-
+  height: 11rem;
 }
 
-#header {
-}
 #header .site-name {
-	margin-top: 1rem;
+  margin-top: 1rem;
 }
+
 #header .site-name a {
-	color: black;
-	font-size: 2rem;
-	font-weight: bold;
-	text-decoration: none;
+  color: black;
+  font-size: 2rem;
+  font-weight: bold;
+  text-decoration: none;
 }
+
 #header .site-slogan {
-	margin-top: -0.5rem;
+  margin-top: -0.5rem;
 }
-#sidebar {
-}
+
 #footer {
-	border-top: 1px solid black;
-	margin-top: 1rem;
-	padding-top: 1rem;
-	width: 100%;
+  border-top: 1px solid black;
+  margin-top: 1rem;
+  padding-top: 1rem;
+  width: 100%;
 }
+
+/*# sourceMappingURL=style.css.map */

--- a/css/text.css
+++ b/css/text.css
@@ -1,58 +1,51 @@
 body {
-	background-color: #fff;
-	color: #555753;
-	font-family: "Verdana", sans-serif;
-	font-size: 12px;
-	font-weight: 400;
-	line-height: 19.2px;
+  background-color: #fff;
+  color: #555753;
+  font-family: "Verdana", sans-serif;
+  font-size: 12px;
+  font-weight: 400;
+  line-height: 19.2px;
 }
 
 #content h1 {
-	color: #765013;
-	font-size: 14px;
-	font-weight: 700;
+  color: #765013;
+  font-size: 14px;
+  font-weight: 700;
 }
 
 #content h2 {
-	color: #4B5C23;
-	font-size: 13px;
-	font-weight: 700;
+  color: #4B5C23;
+  font-size: 13px;
+  font-weight: 700;
 }
 
 #content h3 {
-	color: #4B5C23;
-	font-size: 12px;
-	font-weight: 700;
+  color: #4B5C23;
+  font-size: 12px;
+  font-weight: 700;
 }
 
 #content h4 {
-	color: #555753;
-	font-size: 12px;
-	font-weight: 700;
-}
-
-#content p {
-}
-
-#content li {
-}
-
-#content ol {
+  color: #555753;
+  font-size: 12px;
+  font-weight: 700;
 }
 
 #content ul {
-	padding-left: 2rem;
-	list-style-image: url('../img/bullet-arrow-transparent.png');
+  padding-left: 2rem;
+  list-style-image: url("../img/bullet-arrow-transparent.png");
 }
 
 #content table {
-	border: 1px solid #000066;
+  border: 1px solid #000066;
 }
 
 #content td {
-	background-color: #f8f8f3;
+  background-color: #f8f8f3;
 }
 
 #content th {
-	background-color: #e9e9d1;
+  background-color: #e9e9d1;
 }
+
+/*# sourceMappingURL=text.css.map */

--- a/scss/callouts.scss
+++ b/scss/callouts.scss
@@ -1,0 +1,105 @@
+/* Block styles */
+/* Case in point */
+#content div.case-in-point:before {
+	content: url('../img/point.gif');
+	padding-right: 0.5rem;
+	vertical-align: -50%;
+}
+
+/* Check this out */
+#content div.check-out:before {
+	content: url('../img/checkmark.gif');
+	padding-right: 0.5rem;
+	vertical-align: -50%;
+}
+
+/* "Did you know" sidebar (either left or right) */
+#content div.did-you-know {
+	background: #fbfaf7;
+	box-shadow: 4px 4px 2px #888;
+	margin-bottom: 1rem;
+	padding: 0.5rem;
+	width: 30%;
+}
+#content div.did-you-know.right {
+	clear: right;
+	float: right;
+	margin-left: 1rem;
+}
+#content div.did-you-know.left {
+	clear: left;
+	float: left;
+	margin-right: 1rem;
+}
+#content div.did-you-know h3 {
+	color: black;
+	border-bottom: 1px solid black;
+	margin-top: 0;
+}
+
+/* Exercise callout */
+#content div.exercise {
+	background: #fbfaf7;
+	border-bottom: 1rem solid #765013;
+	margin: 0 auto;
+	width: 90%;
+}
+#content div.exercise h3 {
+	background: #765013;
+	color: #fff;
+	margin-top: 0;
+	text-align: center;
+}
+#content div.exercise p {
+	padding: 0.25rem;
+}
+
+/* Highlight callout (Case in point, etc) */
+#content div.highlight {
+	background: #FBF9F6;
+	border: 1px solid #ddd2c2;
+	box-shadow: 4px 4px 2px #888;
+	clear: both;
+	margin: 0 auto;
+	margin-top: 1rem;
+	width: 80%;
+}
+
+/* Suggested actions */
+#content div.suggested:before {
+	content: url('../img/action.gif');
+	padding-right: 0.5rem;
+	vertical-align: -50%;
+}
+
+/* Watch this spot */
+#content div.watch-this:before {
+	content: url('../img/watch_glass.gif');
+	padding-right: 0.5rem;
+	vertical-align: -50%;
+}
+
+/* Inline styles */
+/* Organizational challenge */
+#content span.manager {
+	font-family: "Georgia", "Times New Roman", "Times", serif;
+	font-size: 14px;
+	font-weight: 700;
+	color: #ca0000;
+}
+
+/* Technical challenge */
+#content span.technical {
+	font-family: "Georgia", "Times New Roman", "Times", serif;
+	font-size: 14px;
+	font-weight: 700;
+	color: #EEA643;
+}
+
+/* Resource challenge */
+#content span.resource {
+	font-family: "Georgia", "Times New Roman", "Times", serif;
+	font-size: 14px;
+	font-weight: 700;
+	color: #6f8531;
+}

--- a/scss/selfquiz.scss
+++ b/scss/selfquiz.scss
@@ -1,0 +1,43 @@
+.selfquiz {
+	padding: 8px 0;
+}
+.selfquiz .question {
+	padding-bottom: 8px;
+}
+.selfquiz .prompt {
+	font-size: 16px;
+	font-weight: bold;
+	padding-bottom: 8px;
+}
+.selfquiz .feedback {
+	font-size: 14px;
+	color: red;
+	padding-bottom: 16px;
+}
+.selfquiz .answers {
+	font-size: 14px;
+	list-style-type: none;
+	padding-bottom: 4px;
+	padding-left: 0;
+}
+.selfquiz .answers label {
+	font-weight: normal;
+}
+.selfquiz .answers li {
+	padding-bottom: 4px;
+}
+.selfquiz .score {
+	color: red;
+	font-size: 20px;
+	font-weight: bold;
+	padding-bottom: 16px;
+}
+.selfquiz .correct {
+	background: #66ff66;
+}
+.selfquiz .wrong {
+	background: #ff6666;
+}
+.selfquiz .hidden {
+	display: none;
+}

--- a/scss/style.scss
+++ b/scss/style.scss
@@ -1,0 +1,58 @@
+body {
+	background: #fff url('../img/background.png') top left no-repeat;
+	color: #000;
+}
+
+.row {
+	display: flex;
+	flex-direction: row;
+	flex-wrap: wrap;
+	width: 100%;
+}
+
+.column {
+	display: flex;
+	flex-direction: column;
+	flex-basis: 100%;
+	flex: 1;
+}
+
+.wrapper {
+	margin: 1rem;
+	max-width: 61rem;
+}
+.thincolumn {
+	max-width: 11rem;
+}
+.masthead {
+	height: 11rem;
+}
+.main {
+
+}
+.colophon {
+
+}
+
+#header {
+}
+#header .site-name {
+	margin-top: 1rem;
+}
+#header .site-name a {
+	color: black;
+	font-size: 2rem;
+	font-weight: bold;
+	text-decoration: none;
+}
+#header .site-slogan {
+	margin-top: -0.5rem;
+}
+#sidebar {
+}
+#footer {
+	border-top: 1px solid black;
+	margin-top: 1rem;
+	padding-top: 1rem;
+	width: 100%;
+}

--- a/scss/superfish.scss
+++ b/scss/superfish.scss
@@ -1,23 +1,18 @@
-@charset "UTF-8";
 ul.sf-menu.sf-style-none {
   float: left;
   margin-bottom: 1em;
   padding: 0;
 }
-
 ul.sf-menu.sf-style-none li {
   float: none;
 }
-
 ul.sf-menu.sf-style-none.sf-navbar {
   width: 100%;
 }
-
 ul.sf-menu.sf-style-none ul {
   margin: 0;
   padding: 0;
 }
-
 ul.sf-menu.sf-style-none a,
 ul.sf-menu.sf-style-none a:visited,
 ul.sf-menu.sf-style-none span.nolink {
@@ -27,18 +22,15 @@ ul.sf-menu.sf-style-none span.nolink {
   padding: 0.75em 0em;
   text-decoration: none;
 }
-
 ul.sf-menu.sf-style-none a.sf-with-ul,
 ul.sf-menu.sf-style-none span.nolink.sf-with-ul {
   padding-right: 2.25em;
 }
-
 ul.sf-menu.sf-style-none.rtl a.sf-with-ul,
 ul.sf-menu.sf-style-none.rtl span.nolink.sf-with-ul {
   padding-left: 2.25em;
   padding-right: 1em;
 }
-
 ul.sf-menu.sf-style-none span.sf-description {
   color: #aaa;
   display: block;
@@ -47,27 +39,22 @@ ul.sf-menu.sf-style-none span.sf-description {
   margin: 0.25em 0 0 0;
   padding: 0;
 }
-
 ul.sf-menu.sf-style-none li,
 ul.sf-menu.sf-style-none.sf-navbar {
   /* background: #fafafa; */
 }
-
 ul.sf-menu.sf-style-none ul a,
 ul.sf-menu.sf-style-none ul a:visited,
 ul.sf-menu.sf-style-none ul span.nolink {
   padding: 0.75em 1em;
 }
-
 ul.sf-menu.sf-style-none li li,
 ul.sf-menu.sf-style-none.sf-navbar > li > ul {
   background: #f7f7f7;
 }
-
 ul.sf-menu.sf-style-none li li li {
   background: #f4f4f4;
 }
-
 ul.sf-menu.sf-style-none li:hover,
 ul.sf-menu.sf-style-none li.sfHover,
 ul.sf-menu.sf-style-none a:focus,
@@ -77,15 +64,12 @@ ul.sf-menu.sf-style-none span.nolink:hover {
   outline: 0;
   text-decoration: underline;
 }
-
 .sf-menu.sf-style-none.sf-navbar li ul {
   background: #f7f7f7;
 }
-
 .sf-menu.sf-style-none.sf-navbar li ul li ul {
   background: transparent;
 }
-
 div.sf-accordion-toggle.sf-style-none a {
   background: #210c02;
   border: 1px solid #381301;
@@ -95,8 +79,7 @@ div.sf-accordion-toggle.sf-style-none a {
   padding: 1em 3em 1em 1em;
   position: relative;
 }
-
-div.sf-accordion-toggle.sf-style-none > a:after {
+div.sf-accordion-toggle.sf-style-none  > a:after {
   content: "≡";
   font-size: 2em;
   position: absolute;
@@ -108,18 +91,15 @@ div.sf-accordion-toggle.sf-style-none > a:after {
   transform: translateY(-50%);
   speak: none;
 }
-
 div.sf-accordion-toggle.sf-style-none a.sf-expanded,
 ul.sf-menu.sf-style-none.sf-accordion li.sf-expanded {
   background: #52250f;
 }
-
 div.sf-accordion-toggle.sf-style-none a.sf-expanded,
 ul.sf-menu.sf-style-none.sf-accordion li.sf-expanded > a,
 ul.sf-menu.sf-style-none.sf-accordion li.sf-expanded > span.nolink {
   font-weight: bold;
 }
-
 ul.sf-menu.sf-style-none.sf-accordion li a.sf-accordion-button {
   font-weight: bold;
   position: absolute;
@@ -127,60 +107,48 @@ ul.sf-menu.sf-style-none.sf-accordion li a.sf-accordion-button {
   top: 0;
   z-index: 499;
 }
-
 ul.sf-menu.sf-style-none.sf-accordion li li a,
 ul.sf-menu.sf-style-none.sf-accordion li li span.nolink {
   padding-left: 2em;
 }
-
 ul.sf-menu.sf-style-none.sf-accordion li li li a,
 ul.sf-menu.sf-style-none.sf-accordion li li li span.nolink {
   padding-left: 3em;
 }
-
 ul.sf-menu.sf-style-none.sf-accordion li li li li a,
 ul.sf-menu.sf-style-none.sf-accordion li li li li span.nolink {
   padding-left: 4em;
 }
-
 ul.sf-menu.sf-style-none.sf-accordion li li li li li a,
 ul.sf-menu.sf-style-none.sf-accordion li li li li li span.nolink {
   padding-left: 5em;
 }
-
 ul.sf-menu.sf-style-none.rtl.sf-accordion li li a,
 ul.sf-menu.sf-style-none.rtl.sf-accordion li li span.nolink {
   padding-left: auto;
   padding-right: 2em;
 }
-
 ul.sf-menu.sf-style-none.rtl.sf-accordion li li li a,
 ul.sf-menu.sf-style-none.rtl.sf-accordion li li li span.nolink {
   padding-left: auto;
   padding-right: 3em;
 }
-
 ul.sf-menu.sf-style-none.rtl.sf-accordion li li li li a,
 ul.sf-menu.sf-style-none.rtl.sf-accordion li li li li span.nolink {
   padding-left: auto;
   padding-right: 4em;
 }
-
 ul.sf-menu.sf-style-none.rtl.sf-accordion li li li li li a,
 ul.sf-menu.sf-style-none.rtl.sf-accordion li li li li li span.nolink {
   padding-left: auto;
   padding-right: 5em;
 }
-
 ul.sf-menu.sf-style-none li.sf-multicolumn-wrapper ol,
 ul.sf-menu.sf-style-none li.sf-multicolumn-wrapper ol li {
   margin: 0;
   padding: 0;
 }
-
 ul.sf-menu.sf-style-none li.sf-multicolumn-wrapper a.menuparent,
 ul.sf-menu.sf-style-none li.sf-multicolumn-wrapper span.nolink.menuparent {
   font-weight: bold;
 }
-
-/*# sourceMappingURL=superfish.css.map */

--- a/scss/text.scss
+++ b/scss/text.scss
@@ -1,0 +1,58 @@
+body {
+	background-color: #fff;
+	color: #555753;
+	font-family: "Verdana", sans-serif;
+	font-size: 12px;
+	font-weight: 400;
+	line-height: 19.2px;
+}
+
+#content h1 {
+	color: #765013;
+	font-size: 14px;
+	font-weight: 700;
+}
+
+#content h2 {
+	color: #4B5C23;
+	font-size: 13px;
+	font-weight: 700;
+}
+
+#content h3 {
+	color: #4B5C23;
+	font-size: 12px;
+	font-weight: 700;
+}
+
+#content h4 {
+	color: #555753;
+	font-size: 12px;
+	font-weight: 700;
+}
+
+#content p {
+}
+
+#content li {
+}
+
+#content ol {
+}
+
+#content ul {
+	padding-left: 2rem;
+	list-style-image: url('../img/bullet-arrow-transparent.png');
+}
+
+#content table {
+	border: 1px solid #000066;
+}
+
+#content td {
+	background-color: #f8f8f3;
+}
+
+#content th {
+	background-color: #e9e9d1;
+}


### PR DESCRIPTION
## Status
_Use labels (`review needed`, `in progress`, or `paused`) to declare status_

#### What does this PR do?
This restructures the theme's styles (minimally) to implement SCSS pre-compiling. Further changes will be coming, but for now this just moves the existing CSS stylesheets into an `/scss` directory.

Developers are expected to run SCSS on their local boxes, because our system currently cannot run this step during deploy time (that's part of future work).

#### Helpful background context (if appropriate)
There are some coming changes to this theme that will require us to compile separate stylesheets for uses like the CKeditor, so getting SCSS in place now - with no actual style changes - is a pre-requisite for that work.

#### How can a reviewer manually see the effects of these changes?
There are no visible impacts to this change. If you see anything that is materially different in the stylesheets, please let me know.

#### Requires Database Migrations?
NO

#### Includes new or updated dependencies?
NO
